### PR TITLE
Delete movement flags

### DIFF
--- a/src/chess.cpp
+++ b/src/chess.cpp
@@ -6,11 +6,11 @@ int main() {
 	Game game = Game();
 
 	game.makeMove(Utils::enumPieces::knight, 6, 21);
-	game.makeMove(Utils::enumPieces::rook, 56, 63);
-	game.makeMove(Utils::enumPieces::bishop, 5, 23);
+	game.makeMove(Utils::enumPieces::bishop, 61, 57);
+	game.makeMove(Utils::enumPieces::rook, 7, 55);
 	game.makeMove(Utils::enumPieces::pawn, 48, 32);
 	game.makeMove(Utils::enumPieces::queen, 4, 3);
-	game.makeMove(Utils::enumPieces::king, 60, 61);
+	game.makeMove(Utils::enumPieces::king, 60, 56);
 
 	return 0;
 }

--- a/src/chess.cpp
+++ b/src/chess.cpp
@@ -5,12 +5,12 @@
 int main() {
 	Game game = Game();
 
-	game.makeMove(Utils::enumPieces::knight, 6, 21, Utils::flagsType::quietMove);
-	game.makeMove(Utils::enumPieces::rook, 56, 63, Utils::flagsType::quietMove);
-	game.makeMove(Utils::enumPieces::bishop, 5, 23, Utils::flagsType::quietMove);
-	game.makeMove(Utils::enumPieces::pawn, 48, 32, Utils::flagsType::quietMove);
-	game.makeMove(Utils::enumPieces::queen, 4, 3, Utils::flagsType::quietMove);
-	game.makeMove(Utils::enumPieces::king, 60, 61, Utils::flagsType::quietMove);
+	game.makeMove(Utils::enumPieces::knight, 6, 21);
+	game.makeMove(Utils::enumPieces::rook, 56, 63);
+	game.makeMove(Utils::enumPieces::bishop, 5, 23);
+	game.makeMove(Utils::enumPieces::pawn, 48, 32);
+	game.makeMove(Utils::enumPieces::queen, 4, 3);
+	game.makeMove(Utils::enumPieces::king, 60, 61);
 
 	return 0;
 }

--- a/src/chess.cpp
+++ b/src/chess.cpp
@@ -6,7 +6,7 @@ int main() {
 	Game game = Game();
 
 	game.makeMove(Utils::enumPieces::knight, 6, 21);
-	game.makeMove(Utils::enumPieces::bishop, 61, 57);
+	game.makeMove(Utils::enumPieces::bishop, 61, 47);
 	game.makeMove(Utils::enumPieces::rook, 7, 55);
 	game.makeMove(Utils::enumPieces::pawn, 48, 32);
 	game.makeMove(Utils::enumPieces::queen, 4, 3);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1,4 +1,5 @@
 #include "game.h"
+#include <ios>
 
 void Game::newTurn() {
 	this->turnCount++;
@@ -21,6 +22,49 @@ Player& Game::getNextPlayer() {
 	}
 }
 
+void Game::determineMovementType(Move &move) {
+	auto pt = move.getPieceType();
+
+	bool capture{false};
+	bool castle{false};
+	
+	// Get a bitboard of the current player
+	U64 currentPlayerBoard = this->m_Board.getAllPiecesOfAGivenPlayer(this->getCurrentPlayer());
+	U64 otherPlayerBoard = this->m_Board.getAllPiecesOfAGivenPlayer(this->getNextPlayer());
+
+	U64 toSquare = static_cast<std::uint_fast64_t>(1) << move.getTo();
+
+	// Determine if is castle
+	if(this->getCurrentPlayer().canPlayerCastle()) {
+		if((pt == Utils::enumPieces::rook) || (pt == Utils::enumPieces::king)) {
+			if (pt == Utils::enumPieces::rook) {
+				// The piece must be moved to the king
+				U64 bitboardOfKings{this->m_Board.getPieceSet(Utils::enumPieces::king)};
+				U64 kingBitboard{bitboardOfKings & currentPlayerBoard};
+
+				if((toSquare & kingBitboard) != 0) {
+					castle = true;
+				}
+			} else {
+				// King
+				// The piece must be moved to the rook
+				U64 bitboardOfRooks{this->m_Board.getPieceSet(Utils::enumPieces::rook)};
+				U64 rookBitboard{bitboardOfRooks & currentPlayerBoard};
+
+				if((toSquare & rookBitboard) != 0) {
+					castle = true;
+				}
+			}
+		}
+	}
+
+	// Determine if is capture
+	if((toSquare & otherPlayerBoard) != 0) {
+		capture = true;
+	}
+}
+
+// Allow to pass piece to promote to
 U64 Game::makeMove(Utils::enumPieces pt, std::uint_fast8_t from, std::uint_fast8_t to) {
 	// Get all the given pieces of type from a player
 	//U64 ptPieces{this->m_Board.getPieceSetOfAGivenPlayer(pt, color)};
@@ -34,7 +78,9 @@ U64 Game::makeMove(Utils::enumPieces pt, std::uint_fast8_t from, std::uint_fast8
 
 	//this->m_Board.updateBoard(pt, color, ptPieces);
 	Move move = Move(pt, getCurrentPlayer(), from, to);
+	this->determineMovementType(move);
 	
+	// Make param constants
 	MoveValidator validator = MoveValidator(this->m_Board, move, this->getCurrentPlayer());
 	bool isValid = validator.validate();
 	std::cout << "Movement is: " << std::boolalpha << isValid << '\n';

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -21,7 +21,7 @@ Player& Game::getNextPlayer() {
 	}
 }
 
-U64 Game::makeMove(Utils::enumPieces pt, std::uint_fast8_t from, std::uint_fast8_t to, Utils::flagsType moveType) {
+U64 Game::makeMove(Utils::enumPieces pt, std::uint_fast8_t from, std::uint_fast8_t to) {
 	// Get all the given pieces of type from a player
 	//U64 ptPieces{this->m_Board.getPieceSetOfAGivenPlayer(pt, color)};
 	//U64 pieceToMove{ptPieces & from};
@@ -29,12 +29,11 @@ U64 Game::makeMove(Utils::enumPieces pt, std::uint_fast8_t from, std::uint_fast8
 	// Delete the old position of the piece
 	//ptPieces = (ptPieces ^ pieceToMove);
 
-	// TODO: Check if movement is valid
 	// Set the new position
 	//ptPieces = (ptPieces | to);
 
 	//this->m_Board.updateBoard(pt, color, ptPieces);
-	Move move = Move(pt, getCurrentPlayer(), from, to, moveType);
+	Move move = Move(pt, getCurrentPlayer(), from, to);
 	
 	MoveValidator validator = MoveValidator(this->m_Board, move, this->getCurrentPlayer());
 	bool isValid = validator.validate();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -59,9 +59,11 @@ void Game::determineMovementType(Move &move) {
 	}
 
 	// Determine if is capture
+	// TODO: En passant
 	if((toSquare & otherPlayerBoard) != 0) {
 		capture = true;
 	}
+	move.setUpFlags(castle, capture);
 }
 
 // Allow to pass piece to promote to

--- a/src/game.h
+++ b/src/game.h
@@ -17,12 +17,15 @@ class Game {
 private:
 	Player white;
 	Player black;
+	// TODO: Change to m_board
 	Board m_Board{};
 
 	int turnCount{1};
 	bool currentTurn{};
 
 	void newTurn();
+
+	void determineMovementType(Move& move);
 public:
 	Game() : white(Utils::Color::whitePLayer), black(Utils::Color::blackPlayer) {
 		// White starts

--- a/src/game.h
+++ b/src/game.h
@@ -35,8 +35,7 @@ public:
 	Player& getNextPlayer();
 
 	// Allow "to" to be expressed in chess notation (ej. f4)
-	U64 makeMove(Utils::enumPieces pt, std::uint_fast8_t from, std::uint_fast8_t to, Utils::flagsType moveType);
-
+	U64 makeMove(Utils::enumPieces pt, std::uint_fast8_t from, std::uint_fast8_t to);
 };
 
 #endif

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -14,15 +14,23 @@ Utils::enumPieces Move::getPieceType() {
 
 // Utility
 bool Move::isCapture() {
-	std::cout << "Color: "<<  pj.getPlayerColor() <<'\n';
-//	return ((this->flags >> 2) == 1) ? true : false;
-	return false;
+	return this->capture;
 };
 
+bool Move::isCastle() {
+	return this->castle;
+}
+
 bool Move::isPromotion() {
-	//return ((this->flags >> 3) == 1) ? true : false;
-	return false;
+	return this->promotion;
 };
+
+
+void Move::setUpFlags(bool castle, bool capture) {
+	this->castle = castle;
+	this->capture = capture;
+}
+
 
 int Move::obtainFileFromSquare(std::uint_fast8_t square) {
 	float division = (static_cast<float>(square) / 8);

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -1,14 +1,6 @@
 #include "move.h"
 
-bool Move::isCapture() {
-	std::cout << "Color: "<<  pj.getPlayerColor() <<'\n';
-	return ((this->flags >> 2) == 1) ? true : false;
-};
-
-bool Move::isPromotion() {
-	return ((this->flags >> 3) == 1) ? true : false;
-};
-
+// Getters
 std::uint_fast8_t Move::getTo() {
 	return this->to;
 }
@@ -16,14 +8,21 @@ std::uint_fast8_t Move::getTo() {
 std::uint_fast8_t Move::getFrom() {
 	return this->from;
 }
-
-Utils::flagsType Move::getFlags() {
-	return this->flags;
-}
-
 Utils::enumPieces Move::getPieceType() {
 	return this->pt;
 }
+
+// Utility
+bool Move::isCapture() {
+	std::cout << "Color: "<<  pj.getPlayerColor() <<'\n';
+//	return ((this->flags >> 2) == 1) ? true : false;
+	return false;
+};
+
+bool Move::isPromotion() {
+	//return ((this->flags >> 3) == 1) ? true : false;
+	return false;
+};
 
 int Move::obtainFileFromSquare(std::uint_fast8_t square) {
 	float division = (static_cast<float>(square) / 8);

--- a/src/move.h
+++ b/src/move.h
@@ -15,6 +15,10 @@ private:
 
 	Utils::enumPieces pieceToPromoteTo{};
 
+	bool promotion;
+	bool castle;
+	bool capture;
+
 public:
 	// Allow to update "to" and "from" after initilization???
 	Move(Utils::enumPieces piece, Player &player, std::uint_fast8_t origin, std::uint_fast8_t destination) : pt(piece), pj(player), from(origin), to(destination)
@@ -24,7 +28,7 @@ public:
 
 	Move(Utils::enumPieces piece, Player &player, std::uint_fast8_t origin, std::uint_fast8_t destination, Utils::enumPieces promotion) : pt(piece), pj(player), from(origin), to(destination), pieceToPromoteTo{promotion}
 	{
-
+		this->promotion = true;
 	}
 
 	// Return string (Ex. A1 or 1 (square number)) ??
@@ -33,7 +37,11 @@ public:
 	Utils::enumPieces getPieceType();
 
 	bool isCapture();
+	// After we know that castle is impossible don't check again
+	bool isCastle();
 	bool isPromotion();
+
+	void setUpFlags(bool castle, bool capture);
 
 	// Takes a square in LERF notation and convert it into the number of the file or of the rank
 	// TODO: Remove as a member function??

--- a/src/move.h
+++ b/src/move.h
@@ -9,20 +9,27 @@ class Move
 private:
 	Utils::enumPieces pt;
 	Player &pj;
+
 	std::uint_fast8_t from;
 	std::uint_fast8_t to;
-	Utils::flagsType flags;
+
+	Utils::enumPieces pieceToPromoteTo{};
 
 public:
 	// Allow to update "to" and "from" after initilization???
-	Move(Utils::enumPieces piece, Player &player, std::uint_fast8_t origin, std::uint_fast8_t destination, Utils::flagsType movementCode) : pt(piece), pj(player), from(origin), to(destination), flags(movementCode)
+	Move(Utils::enumPieces piece, Player &player, std::uint_fast8_t origin, std::uint_fast8_t destination) : pt(piece), pj(player), from(origin), to(destination)
 	{
+
+	}
+
+	Move(Utils::enumPieces piece, Player &player, std::uint_fast8_t origin, std::uint_fast8_t destination, Utils::enumPieces promotion) : pt(piece), pj(player), from(origin), to(destination), pieceToPromoteTo{promotion}
+	{
+
 	}
 
 	// Return string (Ex. A1 or 1 (square number)) ??
 	std::uint_fast8_t getTo();
 	std::uint_fast8_t getFrom();
-	Utils::flagsType getFlags();
 	Utils::enumPieces getPieceType();
 
 	bool isCapture();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3,3 +3,12 @@
 Utils::Color Player::getPlayerColor() {
 	return this->m_color;
 }
+
+// Castle
+void Player::disallowCastle() {
+	this->canCastle = false;
+}
+
+bool Player::canPlayerCastle() {
+	return this->canCastle;
+}

--- a/src/player.h
+++ b/src/player.h
@@ -8,6 +8,7 @@
 
 class Player{
 	Utils::Color m_color;
+	bool canCastle{true};
 
 public:
 	Player(Utils::Color color) : m_color(color){};
@@ -16,6 +17,8 @@ public:
 
 	Utils::Color getPlayerColor();
 
+	void disallowCastle();
+	bool canPlayerCastle();
 };
 
 #endif

--- a/src/utils/moveValidator.cpp
+++ b/src/utils/moveValidator.cpp
@@ -73,9 +73,10 @@ std::vector<Utils::enumSquare> MoveValidator::calculatePath() {
 			// TODO: Check if this works
 			// Dont rely on flags?? 
 			//if(!(move.getFlags() == Utils::flagsType::capture) || !(move.getFlags() == Utils::flagsType::epCapture)) {
+			if(!(move.isCapture())) {
 				// Piece is trying to go diagonally without capturing a piece
-			//	throw -1;
-			//}
+				throw -1;
+			}
 			// TODO: Implement board frame check (Don't allow movement by moving outside of the board)
 			// (Ej. from file 8 to 1)
 			if ((std::abs(finalFile - startingFile)) == 1 )  {

--- a/src/utils/moveValidator.cpp
+++ b/src/utils/moveValidator.cpp
@@ -8,13 +8,21 @@ bool MoveValidator::validate() {
 	// IMPORTANT
 	U64 piece = (static_cast<std::uint_fast64_t>(1) << move.getFrom());
 	bool condition = ((piece & pieceBoardOfCurrentPlayer) != 0);
+	
+	if(move.isCastle()) {
+		if(this->isCastleValid()) {
+
+		} else {
+			return false;
+		}
+	}
 
 	if (!condition) {
 		// The piece is not there
 		// TODO: Add exception
 		return false;
 	}
-
+	
 	// MoveValidator.isCheck();
 	std::vector<Utils::enumSquare> path{};
 
@@ -254,7 +262,6 @@ std::vector<Utils::enumSquare> MoveValidator::calculatePath() {
 		} else if (startingFile == finalFile) {
 			// Vertical movement
 			if(std::abs(move.getFrom() - move.getTo()) == 8) {
-				std::cout << "Pdsdfasdsds\n";
 				path.push_back(static_cast<Utils::enumSquare>(move.getTo()));
 			} else {
 				// Only one square
@@ -275,3 +282,8 @@ std::vector<Utils::enumSquare> MoveValidator::calculatePath() {
 	}
 	return path;
 }
+
+bool MoveValidator::isCastleValid() {
+	return false;
+}
+

--- a/src/utils/moveValidator.cpp
+++ b/src/utils/moveValidator.cpp
@@ -15,59 +15,31 @@ bool MoveValidator::validate() {
 		return false;
 	}
 
-	// Should we determine the flags or they should be provided by the engine??
-	switch (move.getFlags()) {
-		case (Utils::flagsType::quietMove):
-		case (Utils::flagsType::doublePawnPush): {
-			// MoveValidator.isCheck();
-			std::vector<Utils::enumSquare> path{};
+	// MoveValidator.isCheck();
+	std::vector<Utils::enumSquare> path{};
 
-			try {
-				path = this->calculatePath();
-			} catch (int x) {
-				// TODO: Document possible exceptions
-				if (x == -1) {
-					return false;
-				}
-			}
-			// Represents the path that the piece follow
-			U64 movementBoard{};
-			for (auto i : path) {
-				U64 currentSquare = (static_cast<std::uint_fast64_t>(1) << i);
-				std::cout << "Current: " << currentSquare << '\n';
-				movementBoard = (movementBoard | currentSquare);
-			}
+	try {
+		path = this->calculatePath();
+	} catch (int x) {
+		// TODO: Document possible exceptions
+		if (x == -1) {
+			return false;
+		}
+	}
+	// Represents the path that the piece follow
+	U64 movementBoard{};
+	for (auto i : path) {
+		U64 currentSquare = (static_cast<std::uint_fast64_t>(1) << i);
+		std::cout << "Current: " << currentSquare << '\n';
+		movementBoard = (movementBoard | currentSquare);
+	}
 
-			std::cout << "complete: " << movementBoard << '\n';
-			auto completeBoard{this->board.getCompleteBoard()};
+	std::cout << "complete: " << movementBoard << '\n';
+	auto completeBoard{this->board.getCompleteBoard()};
 
-			// No piece intersect during the movement
-			if((completeBoard & movementBoard) == 0) {
-				return true;
-			}
-			break;
-		}
-		case (Utils::flagsType::kingCastle):
-		case (Utils::flagsType::queenCastle): {
-			break;
-		}
-		case (Utils::flagsType::capture):
-		case (Utils::flagsType::epCapture): {
-			break;
-		}
-		case (Utils::flagsType::rookPromotion):
-		case (Utils::flagsType::knightPromotion):
-		case (Utils::flagsType::bishopPromotion):
-		case (Utils::flagsType::queenPromotion): {
-			break;
-		}
-		case (Utils::flagsType::knightPromoAndCapture):
-		case (Utils::flagsType::bishopPromoAndCapture):
-		case (Utils::flagsType::rookPromoAndCapture):
-		case (Utils::flagsType::queenPromoAndCapture): {
-			break;
-			
-		}
+	// No piece intersect during the movement
+	if((completeBoard & movementBoard) == 0) {
+		return true;
 	}
 	return  false;
 }
@@ -92,10 +64,10 @@ std::vector<Utils::enumSquare> MoveValidator::calculatePath() {
 		if(startingFile != finalFile) {
 			// TODO: Check if this works
 			// Dont rely on flags?? 
-			if(!(move.getFlags() == Utils::flagsType::capture) || !(move.getFlags() == Utils::flagsType::epCapture)) {
+			//if(!(move.getFlags() == Utils::flagsType::capture) || !(move.getFlags() == Utils::flagsType::epCapture)) {
 				// Piece is trying to go diagonally without capturing a piece
-				throw -1;
-			}
+			//	throw -1;
+			//}
 			// TODO: Implement board frame check (Don't allow movement by moving outside of the board)
 			// (Ej. from file 8 to 1)
 			if ((std::abs(finalFile - startingFile)) == 1 )  {

--- a/src/utils/moveValidator.h
+++ b/src/utils/moveValidator.h
@@ -19,6 +19,7 @@ public:
 	MoveValidator(Board& currentBoard, Move& movement, Player& player) : board(currentBoard), move(movement), player(player) {};
 
 	bool validate();
+	bool isCastleValid();
 };
 
 #endif

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -41,24 +41,6 @@ namespace Utils{
 		queen,
 		king
 	};
-
-	enum flagsType{
-		quietMove,
-		doublePawnPush,
-		kingCastle,
-		queenCastle,
-		capture,
-		epCapture,
-		knightPromotion,
-		bishopPromotion,
-		rookPromotion,
-		queenPromotion,
-		knightPromoAndCapture,
-		bishopPromoAndCapture,
-		rookPromoAndCapture,
-		queenPromoAndCapture
-	};
-
 };
 
 #endif


### PR DESCRIPTION
Prior to this rework, it was needed in order to check if a movement was valid that the engine passed along with the movement information(the from and to squares)  the type of movement. It was unnecessary since  knowing only  the starting square and the final one we could figure out ourselves the type of movement. This is the work that has been done in this pull request. 